### PR TITLE
Fix plugin name

### DIFF
--- a/docs/en/functions/01_create_instance.mdx
+++ b/docs/en/functions/01_create_instance.mdx
@@ -5,7 +5,7 @@ weight: 01
 # Create Instance
 
 
-Alauda Database Service for MySQL-PXC provides a set of functions to create and manage MySQL database instances in a Kubernetes cluster. Users can quickly deploy MySQL instances that meet their requirements by configuring resource specifications, parameter templates, account information, scheduling policies, and Pod toleration rules. Once the instance is created, some parameters can be adjusted dynamically; however, the scheduling configuration cannot be modified.
+Alauda Database Service for MySQL provides a set of functions to create and manage MySQL database instances in a Kubernetes cluster. Users can quickly deploy MySQL instances that meet their requirements by configuring resource specifications, parameter templates, account information, scheduling policies, and Pod toleration rules. Once the instance is created, some parameters can be adjusted dynamically; however, the scheduling configuration cannot be modified.
 
 ## Prerequisites
 

--- a/docs/en/functions/05_access.mdx
+++ b/docs/en/functions/05_access.mdx
@@ -4,7 +4,7 @@ weight: 05
 
 # Access Methods
 
-Alauda Database Service for MySQL-PXC provides entry points for accessing the database by client applications in several scenarios. In either way the cluster is exposed with regular Kubernetes Service objects , configured by the Operator.
+Alauda Database Service for MySQL provides entry points for accessing the database by client applications in several scenarios. In either way the cluster is exposed with regular Kubernetes Service objects , configured by the Operator.
 
 ## Procedure
 

--- a/docs/en/functions/17_upgrade.mdx
+++ b/docs/en/functions/17_upgrade.mdx
@@ -3,7 +3,7 @@ weight: 17
 ---
 
 # Patch Version Upgrade Strategy
-With the release of vulnerability fixes or new features,  Alauda Database Service for MySQL-PXC will do patch version upgrades. During these patch version upgrades, container groups will be restarted one by one, 
+With the release of vulnerability fixes or new features,  Alauda Database Service for MySQL will do patch version upgrades. During these patch version upgrades, container groups will be restarted one by one, 
 It is recommended to choose an appropriate time window for the upgrade. When an upgradeable patch version appears, it is advised to upgrade as soon as possible to apply the latest fixes to the components.
 
 

--- a/docs/en/installation.mdx
+++ b/docs/en/installation.mdx
@@ -62,12 +62,12 @@ The plugin is a fundamental component of the Data Services view; it can be omitt
   </Tab>
 </Tabs>
 
-## Installing the Alauda Database Service for MySQL-PXC Plugin
+## Installing the Alauda Database Service for MySQL Plugin
 
 ### Prerequisites
 
 1. Download the plugin installation package that matches your platform.
-2. Use the platform's application listing capability to list the plugin in any cluster where you wish to use Alauda Database Service for MySQL-PXC capabilities.
+2. Use the platform's application listing capability to list the plugin in any cluster where you wish to use Alauda Database Service for MySQL capabilities.
 
 ### Procedure
 
@@ -75,7 +75,7 @@ The plugin is a fundamental component of the Data Services view; it can be omitt
   <Tab label="Web Console">
     1. Log in to the platform and go to the **Administrator** page.
     2. In the left navigation bar, select **Marketplace** -> **Operator** to enter the **Operator Hub** page.
-    3. Find **Alauda Database Service for MySQL-PXC**, click **Deploy**, and enter the deployment page.
+    3. Find **Alauda Database Service for MySQL**, click **Deploy**, and enter the deployment page.
 
         Configuration Parameters:
 

--- a/docs/en/intro.mdx
+++ b/docs/en/intro.mdx
@@ -9,7 +9,7 @@ title: Introduction
 
 # Introduction
 
-The **Alauda Database Service for MySQL-PXC** is a Kubernetes-native solution designed to simplify the deployment, management, and scaling of MySQL clusters built on Percona XtraDB Cluster (PXC). The Operator leverages Kubernetes' orchestration capabilities to automate critical database management tasks, including cluster provisioning, backups, failover, and scaling.
+The **Alauda Database Service for MySQL** is a Kubernetes-native solution designed to simplify the deployment, management, and scaling of MySQL clusters built on Percona XtraDB Cluster (PXC). The Operator leverages Kubernetes' orchestration capabilities to automate critical database management tasks, including cluster provisioning, backups, failover, and scaling.
 
 **Percona XtraDB Cluster (PXC)** is an open-source, enterprise-grade MySQL solution designed for high availability and data consistency. It uses synchronous replication to ensure that data is consistent across all nodes in the cluster. PXC provides fault tolerance, automated failover, and scalability, making it ideal for running highly available MySQL databases in mission-critical environments.
 

--- a/docs/en/upgrade.mdx
+++ b/docs/en/upgrade.mdx
@@ -9,6 +9,6 @@ title: Upgrade
 
 # Upgrade
 
-Alauda Database Service for MySQL-PXC will execute upgrades based on the configured upgrade strategy:
+Alauda Database Service for MySQL will execute upgrades based on the configured upgrade strategy:
 - **Automatic** : Auto-upgrades are triggered immediately upon detecting new component versions.
 - **Manual** : Requires manual approval before initiating the upgrade process.

--- a/doom.config.yml
+++ b/doom.config.yml
@@ -1,5 +1,5 @@
-title: Alauda Database Service for MySQL-PXC
-logoText: Alauda Database Service for MySQL-PXC
+title: Alauda Database Service for MySQL
+logoText: Alauda Database Service for MySQL
 lang: en
 api:
   crds:

--- a/sites.yaml
+++ b/sites.yaml
@@ -1,3 +1,3 @@
 - name: acp
   base: /container_platform
-  version: "4.0"
+  version: "fix-plugin-name"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated product name references from “Alauda Database Service for MySQL-PXC” to “Alauda Database Service for MySQL” across intro, installation, access, create instance, and upgrade guides.
  - Aligned plugin naming in UI-related instructions without changing procedures or capabilities.

- Chores
  - Refreshed site branding (title and logo text) to reflect the updated product name.
  - Adjusted site version tag to “fix-plugin-name” for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->