### PR TITLE
docs: update PXC deprecation notices to link to mgr-docs migration guide

### DIFF
--- a/docs/en/architecture.mdx
+++ b/docs/en/architecture.mdx
@@ -3,6 +3,10 @@ weight: 41
 sourceSHA: d95b55c82b2612d70d0cf9b89658a9ca0207e1f397b0d1d4a09c9a67792fbae5
 ---
 
+:::warning Deprecation Notice
+MySQL-PXC is deprecated. Please migrate to MySQL-MGR. See the <ExternalSiteLink name="mysql-mgr" href="/how_to/35-migrate-from-pxc" children="Migration Guide" />.
+:::
+
 # Architecture
 
 *Percona XtraDB Cluster* integrates *Percona Server for MySQL* running

--- a/docs/en/index.mdx
+++ b/docs/en/index.mdx
@@ -7,6 +7,10 @@ sourceSHA: d9c0b197b551666e3a16e9bb84ae6485a1e97db77465f62558e6debb4aa48ad1
 title: Navigation
 ---
 
+:::warning Deprecation Notice
+MySQL-PXC is deprecated and no longer managed by the MySQL operator. Existing PXC clusters will continue to run but will not receive operator updates. Please migrate to MySQL-MGR for continued support. See the <ExternalSiteLink name="mysql-mgr" href="/how_to/35-migrate-from-pxc" children="PXC to MGR Migration Guide" /> for details.
+:::
+
 # Navigation
 
 <Overview overviewHeaders={[]} />

--- a/docs/en/installation.mdx
+++ b/docs/en/installation.mdx
@@ -7,6 +7,10 @@ sourceSHA: 157af7b70d49254846816367d1acb436af0d5803eabe249e346f17fbd372a842
 title: Install
 ---
 
+:::warning Deprecation Notice
+MySQL-PXC is deprecated. Please migrate to MySQL-MGR. See the <ExternalSiteLink name="mysql-mgr" href="/how_to/35-migrate-from-pxc" children="Migration Guide" />.
+:::
+
 # Deployment
 
 ## Installing the Alauda Container Platform Data Services Essentials Plugin

--- a/docs/en/intro.mdx
+++ b/docs/en/intro.mdx
@@ -7,6 +7,10 @@ sourceSHA: b3b3e8faee5f34a1ffe101c47c85f0d80f966d570e7b2f93807392673d2b1db7
 title: Introduction
 ---
 
+:::warning Deprecation Notice
+MySQL-PXC is deprecated and no longer managed by the MySQL operator. Existing PXC clusters will continue to run but will not receive operator updates. Please migrate to MySQL-MGR for continued support. See the <ExternalSiteLink name="mysql-mgr" href="/how_to/35-migrate-from-pxc" children="PXC to MGR Migration Guide" /> for details.
+:::
+
 # Introduction
 
 The **Alauda Database Service for MySQL** is a Kubernetes-native solution designed to simplify the deployment, management, and scaling of MySQL clusters built on Percona XtraDB Cluster (PXC). The Operator leverages Kubernetes' orchestration capabilities to automate critical database management tasks, including cluster provisioning, backups, failover, and scaling.

--- a/docs/en/upgrade.mdx
+++ b/docs/en/upgrade.mdx
@@ -7,6 +7,10 @@ sourceSHA: b3b3e8faee5f34a1ffe101c47c85f0d80f966d570e7b2f93807392673d2b1db7
 title: Upgrade
 ---
 
+:::warning Deprecation Notice
+MySQL-PXC is deprecated and no longer managed by the MySQL operator. Existing PXC clusters will continue to run but will not receive operator updates. Please migrate to MySQL-MGR for continued support. See the <ExternalSiteLink name="mysql-mgr" href="/how_to/35-migrate-from-pxc" children="PXC to MGR Migration Guide" /> for details.
+:::
+
 # Upgrade
 
 Alauda Database Service for MySQL will execute upgrades based on the configured upgrade strategy:

--- a/sites.yaml
+++ b/sites.yaml
@@ -1,3 +1,7 @@
 - name: acp
   base: /container_platform
   version: "fix-plugin-name"
+- name: mysql-mgr
+  base: /mysql-mgr
+  version: "4.3"
+  repo: https://github.com/alauda/mgr-docs


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added deprecation notices across key documentation pages indicating MySQL-PXC is deprecated and no longer managed by the MySQL operator
  * Existing PXC clusters will continue running without operator updates
  * Included links to migration guide for users to transition to MySQL-MGR

* **Chores**
  * Added MySQL-MGR site configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->